### PR TITLE
feat: ignore zenstack syntax when parsing

### DIFF
--- a/packages/prisma-dmmf-extended/src/schemaToDmmf.ts
+++ b/packages/prisma-dmmf-extended/src/schemaToDmmf.ts
@@ -8,9 +8,78 @@ export const schemaToDmmf = async (schema: string) => {
     const { datamodel, config } = await processSchema(schema);
     return { datamodel, config };
   } catch (error) {
-    return handleError(error as Error);
+    try {
+      const { datamodel, config } = await processSchema(
+        removeZenStackSyntax(schema)
+      );
+      return { datamodel, config };
+    } catch (error) {
+      return handleError(error as Error);
+    }
   }
 };
+
+function removeZenStackSyntax(schema: string): string {
+  // Remove import statements
+  schema = schema.replace(/^import\s+.*$/gm, " ");
+
+  // Replace ZenStack plugin blocks with empty lines
+  schema = schema.replace(/plugin\s+\w+\s*{[^}]*}/gs, (match) => {
+    // Count the number of newlines in the matched text
+    const lineCount = (match.match(/\n/g) || []).length;
+    // Return an equivalent number of newlines
+    return "\n".repeat(lineCount);
+  });
+  // Remove @email, @omit, @password attributes
+  schema = schema.replace(/@(email|omit|password)(\(.+?\))?/g, " ");
+
+  // Remove @@allow statements
+  schema = schema
+    .split("\n")
+    .map((line) => {
+      if (line.includes("@@allow")) {
+        return " ";
+      }
+      return line;
+    })
+    .join("\n");
+
+  // Replace models that use extends syntax with empty lines
+  schema = schema.replace(
+    /model\s+\w+\s+extends\s+\w+\s*{[^}]*}/gs,
+    (match) => {
+      const lineCount = (match.match(/\n/g) || []).length;
+      return "\n".repeat(lineCount);
+    }
+  );
+
+  // Remove auth() function calls
+  schema = schema.replace(/auth\(\)/g, " ");
+
+  // Remove @use statements
+  schema = schema.replace(/@use\(.+?\)/g, " ");
+
+  // Remove @relation.fields and @relation.references
+  schema = schema.replace(/@relation\.(fields|references)/g, " ");
+
+  // Remove @default(cuid()) and replace with @default(uuid())
+  schema = schema.replace(/@default\(cuid\(\)\)/g, "@default(uuid())");
+
+  // Remove @(...) attributes that are not standard Prisma attributes
+  // This regex excludes common Prisma attributes
+  schema = schema.replace(
+    /@(?!id|default|unique|relation|updatedAt|map)[\w.]+(\(.+?\))?/g,
+    " "
+  );
+
+  // Remove empty lines and trim whitespace
+  schema = schema
+    .split("\n")
+    .filter((line) => line.trim() !== " ")
+    .join("\n");
+
+  return schema;
+}
 
 async function processSchema(schema: string) {
   const { datamodel: originalDatamodel } = await getDMMF({ datamodel: schema });


### PR DESCRIPTION
this will need to be handled better, maybe use `npx zenstack generate` 